### PR TITLE
handle shebangs, improve overwriting and multi-script packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v10
+    - uses: cachix/install-nix-action@v12
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: nix-build ci.nix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 resholve is not yet versioned (though it will be in the near future). Until it is, I'll list major changes by date.
 
+## Dec 10 2020
+This update marks the start of a period (*hopefully a short one*) with many breaking API changes. I am trying to get a few partially-finished features into the codebase, and will then be largely reworking the flag names before finally tagging an initial 0.1.0 release.
+- *BREAKING*: Improved handling of single packages with multiple scripts (such as submodules.) 
+    - At least for now, all of the scripts you want to resolve should be passed (in the Nix api as `scripts`, and as final arguments on the command line).
+    - In order to make this work, I did need to shift the Nix API to run after the files were already in their final locations--during fixup phase (currently as preFixup). Before this change, `scripts` would be a list of filenames relative to the build, but it is now relative to $out.
+
+    If you had something like `scripts = [ "openssl.sh" ];` to resolve a script before installing it to `$out/bin/openssl.sh` the updated form is: `scripts = [ "bin/openssl.sh" ];`
+- *BREAKING*: resholve is now "handling" the interpreter/shebang. Since resholve doesn't actually understand your shebang, this takes a fairly explicit/declarative/idempotent approach. You now *must* specify an `--interpreter`, which may be
+    - a path, in which case any existing shebang will be stripped and a shebang pointing to only this interpreter added
+    - the magic string 'none', in which case any existing shebang will be stripped and nothing will replace it
+- Made the decision to overwrite a script or not explicit via the `--overwrite` flag (when passed as a path). 
+    - Before, resholve would only overwrite the script when it looked like it was running in a Nix build environment.
+    - The Nix `resholvePackage` function takes care of passing this option, so it should be transparent if you're using the Nix API.
+
 ## Sep 2 2020
 Rename resholved -> resholve (and resholver -> resholve)
 

--- a/resholve
+++ b/resholve
@@ -3,8 +3,8 @@ from __future__ import print_function
 
 import sys
 import os
+import StringIO
 import argparse
-import fileinput
 import logging
 
 from collections import defaultdict
@@ -197,6 +197,20 @@ parser.add_argument(
     dest="resolve_aliases",
     help="Resolve commands inside an alias to absolute paths when possible.",
 )
+parser.add_argument(
+    "--overwrite",
+    action="store_true",
+    dest="overwrite",
+    help="Replace script files instead of writing to script.resolved.",
+)
+parser.add_argument(
+    "--interpreter",
+    dest="interpreter",
+    type=str,
+    metavar="path",
+    help="Specify an interpreter for the shebang. Note: the interpreter doesn't otherwise impact how resholve interprets or rewrites a script.",
+    required=True,
+)
 
 
 def lookup(word):
@@ -213,21 +227,16 @@ def resolve_script(script_path):
     return resolved
 
 
-def write_resolved_script(script_path, resolved):
+def write_resolved_script(script_path, resolved, overwrite=False):
     if not script_path:
         resolved.write_to()
-    elif "NIX_BUILD_TOP" in os.environ and script_path.startswith(
-        os.environ["NIX_BUILD_TOP"]
-    ):
-        logger.info(
-            "script %r located in nix build dir; will attempt to overwrite", script_path
-        )
+    elif overwrite:
+        logger.info("attempting to overwrite script %r", script_path)
         resolved.write_to(script_path)
         sys.stderr.write("Overwrote %r\n" % (script_path))
     else:
         logger.info(
-            "script %r not in Nix build dir; will attempt to write to: %s%s",
-            script_path,
+            "overwrite not set; will attempt to write to: %s%s",
             script_path,
             ".resolved",
         )
@@ -235,6 +244,42 @@ def write_resolved_script(script_path, resolved):
         sys.stderr.write(
             "Rewrote %r to %r\n" % (script_path, script_path + ".resolved")
         )
+
+
+def lookup_source(word):
+    """
+    wrap lookup(word) to special-case source lookups
+
+    lookup can't resolve something like `source submodule/helper.sh`
+    unless we add subdirs to PATH, but that could let all kinds of
+    stuff into the resolution scope.
+
+    Instead, we'll try to resolve source calls from the list of
+    input scripts before giving lookup a chance.
+
+    This is a little weird, but this is a not-implemented stub for
+    documentation. The business-end of this function is temporarily
+    published the sourcePATH() context manager during punshow()
+    """
+    raise NotImplementedError("lookup_source called outside of sourcePATH context")
+
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def sourcePATH(script_map):
+    global lookup_source
+
+    def contextual_lookup_source(word):
+        if word in script_map:
+            return script_map[word]
+        return lookup(word)
+
+    prev = lookup_source
+    lookup_source = contextual_lookup_source
+    yield
+    lookup_source = prev
 
 
 def punshow():
@@ -261,19 +306,31 @@ def punshow():
     if not args.resolve_aliases:
         RecordCommandlike.disable_alias_replacement()
 
+    if args.interpreter == "none":
+        shebang = None
+    else:
+        interp = args.interpreter
+        assert os.path.exists(interp), "Interpreter must exist or be the string 'none'"
+        assert os.path.isabs(interp), "Interpreter path must be absolute"
+        assert os.access(interp, os.X_OK), "Interpreter must be executable"
+        shebang = "#!{:}\n".format(interp)
     try:
         to_write = set()
         if len(args.scripts) == 0:
             # None == <stdin>
-            resolved_scripts[None] = ResolvedScript()
-            to_write.add(None)
+            with sourcePATH(dict()):
+                resolved_scripts[None] = ResolvedScript(shebang=shebang)
+                to_write.add(None)
 
         checked_scripts = list()
-        for script in map(os.path.abspath, args.scripts):
-            if os.path.exists(script):
-                checked_scripts.append(script)
+        script_map = dict()
+        for in_script in args.scripts:
+            abs_script = os.path.abspath(in_script)
+            if os.path.exists(abs_script):
+                checked_scripts.append(abs_script)
+                script_map[in_script] = abs_script
             else:
-                sys.stderr.write("Aborting due to missing file: %r\n" % script)
+                sys.stderr.write("Aborting due to missing file: %r\n" % abs_script)
                 return 2
 
         # TODO: this should probably explain why it's a problem
@@ -284,15 +341,18 @@ def punshow():
             sys.stderr.write("  Distinct: %r\n" % set(checked_scripts))
             return 2
 
-        for script in checked_scripts:
-            resolve_script(script)
-            to_write.add(script)
+        with sourcePATH(script_map):
+            for script in checked_scripts:
+                resolve_script(script)
+                to_write.add(script)
 
         # cmdlikes are cross-source; try to resolve a single time
         resolve_cmdlikes()
 
         for script_path in to_write:
-            write_resolved_script(script_path, resolved_scripts[script_path])
+            write_resolved_script(
+                script_path, resolved_scripts[script_path], args.overwrite
+            )
 
     except IOError as e:
         sys.stderr.write("Whoooo buddy " + str(e))
@@ -928,7 +988,16 @@ class ResolvedScript(RecordCommandlike):
 
     # We need to extract more info after hitting some firstwords
     # This list is just for noticing if something is breaking expectations
-    WATCH_FIRSTWORDS = {"sudo", "command", "eval", "exec", ".", "source", "alias"}
+    WATCH_FIRSTWORDS = {
+        "sudo",
+        "command",
+        "eval",
+        "exec",
+        ".",
+        "source",
+        "alias",
+        "env",
+    }
 
     @staticmethod
     def _make_parser(parse_ctx, script, arena):
@@ -937,10 +1006,37 @@ class ResolvedScript(RecordCommandlike):
         """
         return parse_ctx.MakeOshParser(reader.FileLineReader(script, arena))
 
-    def __init__(self, script_path=None):
+    def replace_shebang(self, fileob, shebang=False):
+        """
+        - skip over the shebang lines, else raise
+        - prepend new shebang if available
+        """
+        pos = fileob.tell()
+        line = fileob.readline()
+
+        while line[0:2] == "#!":
+            if shebang is False:
+                raise Exception(
+                    "Oh gosh :( you gotta get this shebang looked at", line, pos
+                )
+            elif shebang or shebang is None:
+                logger.debug("Skipping shebang line: %r", line)
+
+            pos = fileob.tell()
+            line = fileob.readline()
+
+        logger.debug("First non-shebang line: %r", line)
+        fileob.seek(pos)
+        logger.debug("appending shebang: %r", shebang)
+        return StringIO.StringIO((shebang if shebang else "") + fileob.read())
+
+    def __init__(self, script_path=None, shebang=""):
 
         # generally, defer work until we know the script loaded
         with (open(script_path) if script_path else sys.stdin) as script:
+            if shebang:  # not allow_shebang:
+                script = self.replace_shebang(script, shebang)
+
             arena = alloc.Arena()
             parse_ctx = parse_lib.ParseContext(
                 arena=arena,
@@ -1145,7 +1241,7 @@ class ResolvedScript(RecordCommandlike):
         # source?
 
         # TODO: should builtin be here? Currently not because we don't want to replace them...
-        if word1 in (".", "source", "sudo", "command", "eval", "exec", "alias"):
+        if word1 in self.WATCH_FIRSTWORDS:
             logger.info("Visiting command: %s %s", word1, word2)
             if word1 == "eval" and w_ob2.parts[0].tag in (
                 word_part_e.SingleQuoted,
@@ -1249,12 +1345,12 @@ class ResolvedScript(RecordCommandlike):
                 if word1 in ("command", "eval"):
                     # TODO: not absolutely certain about resolution order here
                     self.record_command_cmd(w_ob2, word2)
-                elif word1 in ("sudo", "exec"):
+                elif word1 in ("sudo", "exec", "env"):
                     # TODO: not absolutely certain about resolution order here
                     self.record_external_cmd(w_ob2, word2)
                 elif word1 in (".", "source"):
                     # CAUTION: in a multi-module library, we'll have to think very carefully about how to look up targets in order to parse them, but *avoid* translating the source statement into an absolute URI. (If this is sticky, another option might be a post-substitute to replace the build-path with the output path?)
-                    target = lookup(word2)
+                    target = lookup_source(word2)
                     logger.debug("Looked up source: %r -> %r", word2, target)
                     # it was already a valid absolute path
                     if target == word2 and target[0] == "/":

--- a/resholve-package.nix
+++ b/resholve-package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, resholve, }:
+{ stdenv, lib, resholve, bash }:
 
 { pname, src, version, scripts, inputs ? [ ], allow ? { }, flags ? [ ], passthru ? { }, ...
 }@attrs:
@@ -12,10 +12,10 @@ let
       RESHOLVE_ALLOW = toString
         (lib.mapAttrsToList (name: value: map (y: name + ":" + y) value) allow);
       #LOGLEVEL="INFO";
-      buildPhase = ''
-        runHook preBuild
-        resholve ${toString (flags ++ scripts)}
-        runHook postBuild
+      preFixup = ''
+        pushd $out
+        resholve --interpreter ${bash}/bin/bash --overwrite ${toString (flags ++ scripts)}
+        popd
       '';
     }));
 in lib.extendDerivation true passthru self

--- a/resholve.nix
+++ b/resholve.nix
@@ -1,5 +1,5 @@
 {
-  stdenv, callPackage, file, findutils, gettext, python27, bats,
+  stdenv, callPackage, file, findutils, gettext, python27, bats, bash,
 
   doCheck ? true
 }:
@@ -35,6 +35,9 @@ in python27.pkgs.buildPythonApplication {
   inherit doCheck;
   checkInputs = [ bats ];
   RESHOLVE_PATH = "${stdenv.lib.makeBinPath resolveTimeDeps}";
+
+  # explicit interpreter for test suite; maybe some better way...
+  INTERP = "${bash}/bin/bash";
   checkPhase = ''
     PATH=$out/bin:$PATH
     patchShebangs .

--- a/tests/behavior.bats
+++ b/tests/behavior.bats
@@ -14,7 +14,7 @@ quoted_eval="FEEDBACK WANTED: Letting quoted 'eval' through"
     line 9 contains "eval_quoted.sh:11: $quoted_eval"
   })
 } <<CASES
-resholve eval_quoted.sh
+resholve --interpreter $INTERP eval_quoted.sh
 CASES
 
 # TODO: replace w/ real test once issue is sorted
@@ -59,5 +59,5 @@ var_as_command="FEEDBACK WANTED: Letting dynamic command (first-word variable) t
 
   })
 } <<CASES
-resholve variable_as_command.sh
+resholve --interpreter $INTERP variable_as_command.sh
 CASES

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -16,6 +16,16 @@
 
 load helpers
 
+@test "invoking resholve without --interpreter prints an error" {
+  unset RESHOLVE_PATH
+  require <({
+    status 2
+    line -1 equals "resholve: error: argument --interpreter is required"
+  })
+} <<CASES
+resholve < file_simple.sh
+resholve file_simple.sh
+CASES
 
 @test "invoking resholve without RESHOLVE_PATH prints an error" {
   unset RESHOLVE_PATH
@@ -24,19 +34,52 @@ load helpers
     line -1 equals "AssertionError: RESHOLVE_PATH must be set"
   })
 } <<CASES
-resholve < file_simple.sh
-resholve file_simple.sh
+resholve --interpreter /usr/bin/env < file_simple.sh
+resholve --interpreter none file_simple.sh
 CASES
 
-@test "invoking resholve without script deps prints an error" {
+@test "invoking resholve with missing interpreter prints an error" {
+  require <({
+    status 1
+    line -1 equals "AssertionError: Interpreter must exist or be the string 'none'"
+  })
+} <<CASES
+resholve --interpreter /blah < file_simple.sh
+resholve --interpreter /blah file_simple.sh
+CASES
+
+@test "invoking resholve with a relative interpreter prints an error" {
+  require <({
+    status 1
+    line -1 equals "AssertionError: Interpreter path must be absolute"
+  })
+  # just using a random relative script as interp
+} <<CASES
+resholve --interpreter aliases.sh < file_simple.sh
+resholve --interpreter aliases.sh file_simple.sh
+CASES
+
+@test "invoking resholve with a non-executable interpreter prints an error" {
+  require <({
+    status 1
+    line -1 equals "AssertionError: Interpreter must be executable"
+  })
+  # just using a random non-executable script as interp
+} <<'CASES'
+resholve --interpreter $PWD/aliases.sh < file_simple.sh
+resholve --interpreter $PWD/aliases.sh file_simple.sh
+CASES
+
+
+@test "invoking resholve without script's deps prints an error" {
   RESHOLVE_PATH=''
   require <({
     status 3
     line -1 contains "Can't resolve command 'file' to a known function or executable"
   })
 } <<CASES
-resholve < file_simple.sh
-resholve file_simple.sh
+resholve --interpreter $INTERP < file_simple.sh
+resholve --interpreter $INTERP file_simple.sh
 CASES
 
 @test "resholve resolves simple external dependency from command-line args" {
@@ -45,8 +88,8 @@ CASES
     line -1 contains "wrote "
   })
 } <<CASES
-resholve file_simple.sh
-resholve file_simple.sh source_present_target.sh
+resholve --interpreter $INTERP file_simple.sh
+resholve --interpreter $INTERP file_simple.sh source_present_target.sh
 CASES
 
 @test "resholve resolves simple external dependency from stdin" {
@@ -58,7 +101,7 @@ CASES
     line -1 ends "/bin/file"
   })
 } <<CASES
-resholve < file_simple.sh
+resholve --interpreter $INTERP < file_simple.sh
 CASES
 
 @test "resholve fails if target script isn't found" {
@@ -68,8 +111,8 @@ CASES
     line -1 begins "Aborting due to missing file: '/hopenot/file_simple.sh'"
   })
 } <<CASES
-resholve /hopenot/file_simple.sh
-resholve file_simple.sh /hopenot/file_simple.sh
+resholve --interpreter $INTERP /hopenot/file_simple.sh
+resholve --interpreter $INTERP file_simple.sh /hopenot/file_simple.sh
 CASES
 
 @test "resholve fails with duplicate input scripts" {
@@ -79,7 +122,7 @@ CASES
     line 1 equals "Aborting due to duplicate script targets."
   })
 } <<CASES
-resholve file_simple.sh source_present_target.sh source_present_target.sh
+resholve --interpreter $INTERP file_simple.sh source_present_target.sh source_present_target.sh
 CASES
 
 @test "resholve fails when scripts have dynamic elements that aren't 'allowed'" {
@@ -89,8 +132,8 @@ CASES
     line -1 contains "Can't resolve 'source' with a dynamic argument"
   })
 } <<CASES
-resholve source_var_pwd.sh
-resholve source_home_pwd.sh
+resholve --interpreter $INTERP source_var_pwd.sh
+resholve --interpreter $INTERP source_home_pwd.sh
 CASES
 
 @test "resholve fails when 'allow' directives are misformatted" {
@@ -100,9 +143,9 @@ CASES
     line -1 contains "should be a scope:var pair"
   })
 } <<CASES
-resholve --allow source PWD source_var_pwd.sh
-resholve --allow PWD source_var_pwd.sh
-resholve < source_var_pwd_bad_annotation.sh
+resholve --interpreter $INTERP --allow source PWD source_var_pwd.sh
+resholve --interpreter $INTERP --allow PWD source_var_pwd.sh
+resholve --interpreter $INTERP < source_var_pwd_bad_annotation.sh
 CASES
 
 @test "resholve fails when 'allow' directive doesn't specify the right thing" {
@@ -112,13 +155,13 @@ CASES
     line -1 contains "Can't resolve 'source' with a dynamic argument"
   })
 } <<CASES
-resholve --allow command:PWD < source_var_pwd.sh
-RESHOLVE_ALLOW='command:PWD' resholve < source_var_pwd.sh
-resholve --allow source:HOME < source_var_pwd.sh
-RESHOLVE_ALLOW='source:HOME' resholve < source_var_pwd.sh
-resholve < source_var_pwd_misannotated.sh
-resholve --allow source:PWD < source_home_pwd.sh
-RESHOLVE_ALLOW='source:PWD' resholve < source_home_pwd.sh
+resholve --interpreter $INTERP --allow command:PWD < source_var_pwd.sh
+RESHOLVE_ALLOW='command:PWD' resholve --interpreter $INTERP < source_var_pwd.sh
+resholve --interpreter $INTERP --allow source:HOME < source_var_pwd.sh
+RESHOLVE_ALLOW='source:HOME' resholve --interpreter $INTERP < source_var_pwd.sh
+resholve --interpreter $INTERP < source_var_pwd_misannotated.sh
+resholve --interpreter $INTERP --allow source:PWD < source_home_pwd.sh
+RESHOLVE_ALLOW='source:PWD' resholve --interpreter $INTERP < source_home_pwd.sh
 CASES
 
 @test "resholve succeeds when 1x 'allow' directives are correct" {
@@ -129,9 +172,9 @@ CASES
     line -1 equals "# resholve: allow source:PWD"
   })
 } <<CASES
-resholve --allow source:PWD < source_var_pwd.sh
-RESHOLVE_ALLOW='source:PWD' resholve < source_var_pwd.sh
-resholve < source_var_pwd_annotated.sh
+resholve --interpreter $INTERP --allow source:PWD < source_var_pwd.sh
+RESHOLVE_ALLOW='source:PWD' resholve --interpreter $INTERP < source_var_pwd.sh
+resholve --interpreter $INTERP < source_var_pwd_annotated.sh
 CASES
 
 @test "resholve succeeds when 2x 'allow' directives are correct" {
@@ -144,30 +187,30 @@ CASES
     line -1 equals "# resholve: allow source:PWD"
   })
 } <<CASES
-resholve --allow source:PWD --allow source:HOME < source_home_pwd.sh
-RESHOLVE_ALLOW='source:PWD source:HOME' resholve < source_home_pwd.sh
-RESHOLVE_ALLOW='source:PWD' resholve --allow source:HOME < source_home_pwd.sh
-RESHOLVE_ALLOW='source:PWD' resholve < source_home_pwd_annotated_incomplete.sh
-resholve --allow source:PWD < source_home_pwd_annotated_incomplete.sh
+resholve --interpreter $INTERP --allow source:PWD --allow source:HOME < source_home_pwd.sh
+RESHOLVE_ALLOW='source:PWD source:HOME' resholve --interpreter $INTERP < source_home_pwd.sh
+RESHOLVE_ALLOW='source:PWD' resholve --interpreter $INTERP --allow source:HOME < source_home_pwd.sh
+RESHOLVE_ALLOW='source:PWD' resholve --interpreter $INTERP < source_home_pwd_annotated_incomplete.sh
+resholve --interpreter $INTERP --allow source:PWD < source_home_pwd_annotated_incomplete.sh
 CASES
 
 @test "Don't resolve aliases without --resolve-aliases" {
   require <({
     status 0
-    line 3 !contains "/nix/store"
-    line 4 !contains 'find="/nix/store'
-    line 4 !contains 'find2="/nix/store'
-    line 6 !contains "/nix/store"
-    line 8 !contains "/nix/store"
-    line 9 contains "/nix/store"
-    line 10 !contains "/nix/store"
-    line 11 contains "/nix/store"
-    line 12 equals "### resholve directives (auto-generated)"
+    line 4 !contains "/nix/store"
+    line 5 !contains 'find="/nix/store'
+    line 6 !contains 'find2="/nix/store'
+    line 7 !contains "/nix/store"
+    line 9 !contains "/nix/store"
+    line 10 contains "/nix/store"
+    line 11 !contains "/nix/store"
+    line 12 contains "/nix/store"
+    line 13 equals "### resholve directives (auto-generated)"
     # can't assert the ends; these get sorted
     # and the hash makes unstable :(
-    line 13 begins "# resholve: allow resholved_inputs:/nix/store/"
     line 14 begins "# resholve: allow resholved_inputs:/nix/store/"
+    line 15 begins "# resholve: allow resholved_inputs:/nix/store/"
   })
 } <<CASES
-resholve < alias_riddle.sh
+resholve --interpreter $INTERP < alias_riddle.sh
 CASES

--- a/tests/demo.bats
+++ b/tests/demo.bats
@@ -16,62 +16,62 @@ load demo
     status 3
   })
 } <<CASES
-resholve < which_simple.sh
+resholve --interpreter $INTERP < which_simple.sh
 CASES
 
 @test "Even in a function, 'which' needs to be in RESHOLVE_PATH" {
   demo "command_in_function.sh" <(status 3)
 } <<CASES
-resholve < command_in_function.sh
+resholve --interpreter $INTERP < command_in_function.sh
 CASES
 
 @test "Absolute executable paths need exemptions" {
   demo "absolute_path.sh" <(status 5)
 } <<CASES
-resholve < absolute_path.sh
+resholve --interpreter $INTERP < absolute_path.sh
 CASES
 
 @test "Source, among others, needs an exemption for arguments containing variables" {
   demo "source_var_pwd.sh" <(status 6)
 } <<CASES
-resholve < source_var_pwd.sh
+resholve --interpreter $INTERP < source_var_pwd.sh
 CASES
 
 @test "Resolves unqualified 'file' to absolute path from RESHOLVE_PATH" {
   demo "file_simple.sh" <(status 0)
 } <<CASES
-resholve < file_simple.sh
+resholve --interpreter $INTERP < file_simple.sh
 CASES
 
 # TODO: maybe it better illustrates to just collapse this test with the above (and tests 1 and 2)
 @test "Even in a function, resolves unqualified 'file' to absolute path from RESHOLVE_PATH" {
   demo "file_in_function.sh" <(status 0)
 } <<CASES
-resholve < file_in_function.sh
+resholve --interpreter $INTERP < file_in_function.sh
 CASES
 
 @test "Only some commands ('source' but NOT 'file', here) are checked for variable arguments." {
   demo "file_home_source_pwd.sh" <(status 6)
 } <<CASES
-resholve < file_home_source_pwd.sh
+resholve --interpreter $INTERP < file_home_source_pwd.sh
 CASES
 
 @test "Add an exemption with --allow <scope>:<name>" {
   demo "file_home_source_pwd.sh" <(status 0)
 } <<CASES
-resholve --allow source:PWD < file_home_source_pwd.sh
+resholve --interpreter $INTERP --allow source:PWD < file_home_source_pwd.sh
 CASES
 
 @test "Add an exemption with RESHOLVE_ALLOW="source:PWD"" {
   demo "file_home_source_pwd.sh" <(status 0)
 } <<CASES
-RESHOLVE_ALLOW="source:PWD" resholve < file_home_source_pwd.sh
+RESHOLVE_ALLOW="source:PWD" resholve --interpreter $INTERP < file_home_source_pwd.sh
 CASES
 
 @test "'source' targets also need to be in RESHOLVE_PATH" {
   demo "source_missing_target.sh" <(status 7)
 } <<CASES
-resholve < source_missing_target.sh
+resholve --interpreter $INTERP < source_missing_target.sh
 CASES
 
 @test "Resolves unqualified 'source' to absolute path from RESHOLVE_PATH" {
@@ -82,26 +82,26 @@ CASES
     line -1 ends "/bin/gettext.sh"
   })
 } <<CASES
-resholve < source_present_target.sh
+resholve --interpreter $INTERP < source_present_target.sh
 CASES
 
 @test "Has (naive) context-specific resolution rules" {
   demo "alias_riddle.sh" <({
     status 0
-    line 3 !contains "/nix/store"
-    line 4 contains 'find="/nix/store'
-    line 4 contains 'find2="/nix/store'
-    line 6 !contains "/nix/store"
-    line 8 !contains "/nix/store"
-    line 9 contains "/nix/store"
-    line 10 !contains "/nix/store"
-    line 11 contains "/nix/store"
-    line 12 equals "### resholve directives (auto-generated)"
+    line 4 !contains "/nix/store"
+    line 5 contains 'find="/nix/store'
+    line 5 contains 'find2="/nix/store'
+    line 7 !contains "/nix/store"
+    line 9 !contains "/nix/store"
+    line 10 contains "/nix/store"
+    line 11 !contains "/nix/store"
+    line 12 contains "/nix/store"
+    line 13 equals "### resholve directives (auto-generated)"
     # can't assert the ends; these get sorted
     # and the hash makes unstable :(
-    line 13 begins "# resholve: allow resholved_inputs:/nix/store/"
     line 14 begins "# resholve: allow resholved_inputs:/nix/store/"
+    line 15 begins "# resholve: allow resholved_inputs:/nix/store/"
   })
 } <<CASES
-resholve --resolve-aliases < alias_riddle.sh
+resholve --interpreter $INTERP --resolve-aliases < alias_riddle.sh
 CASES

--- a/tests/nix/libressl/libressl.sh
+++ b/tests/nix/libressl/libressl.sh
@@ -1,8 +1,12 @@
+source submodule/helper.sh
+
 libressl_sh() {
     set -x
     jq -n --arg greeting world '{"hello":$greeting}'
     openssl version
     set +x
 }
+
+just_being_helpful
 
 source openssl.sh

--- a/tests/nix/libressl/submodule/helper.sh
+++ b/tests/nix/libressl/submodule/helper.sh
@@ -1,0 +1,3 @@
+just_being_helpful(){
+	echo "much help"
+}


### PR DESCRIPTION
This is a bit of a kitchen sink. 

My time to look at resholve has been intermittent over the fall and I ended up absentmindedly stubbing out overlapping draft fixes/features in the same work tree. I want to clear my plate to focus on reworking the ~API (flags and envs), but I expect that to cause a good bit of code/test/doc churn--so I want to land these instead of stash them.

There are some breaking changes here, so I'm opening a PR to leave a more visible breadcrumb trail and make space for questions if any arise. See [CHANGELOG.md - Dec 10 2020](https://github.com/abathur/resholve/blob/source_submodule/CHANGELOG.md#dec-10-2020) (or how the
test suite and demos were modified) to get a sense of how you
can adjust to them if needed.

At a high level:
- Handle single (Nix) packages with multiple scripts better. Scripts are now resolved in the fixup phase (instead of the build phase), so that package-internal references pick up the correct $out paths.
- Handle the interpreter/shebang. Resholve is technically blind to the shebang, so it now uses a simple/crude approach. You must now declare *some* interpreter. If you assert a path, resholve will verify it, strip any existing shebang, and write the new one. If you assert a magic 'none' value, resholve will strip the shebang, providing a relief valve if you need a bespoke shebang. Closes #15 
- Control of whether resholve will overwrite a script or write to `<script>.resolved` is now explicit via the `--overwrite` flag (before overwrite was ~magically enabled during Nix builds). This is only relevant if you're using resholve directly on the command line.

