### PR TITLE
try to fix leaky pythonpath

### DIFF
--- a/resholve-package.nix
+++ b/resholve-package.nix
@@ -72,7 +72,7 @@ let
   /* Build a single resholve invocation */
   makeInvocation = solution: value:
     if validateSolution value then
-      "${makeEnvs solution value} resholve --overwrite ${makeArgs value}"
+      "${makeEnvs solution value} ${resholve}/bin/resholve --overwrite ${makeArgs value}"
     else throw "invalid solution"; # shouldn't trigger for now
 
   /* Build resholve invocation for each solution. */
@@ -82,7 +82,6 @@ let
   self = (stdenv.mkDerivation ((removeAttrs attrs [ "solutions" ])
     // {
     inherit pname version src;
-    buildInputs = [ resholve ];
 
     # enable below for verbose debug info if needed
     # supports default python.logging levels


### PR DESCRIPTION
This weekend I was working on adding a test suite for https://github.com/abathur/lilgit, which has a python38 ~daemon component built with buildPythonPackage, and a bash script built with resholvePackage.

While running tests inside the build, I caught it throwing these errors:
```
# Traceback (most recent call last):
#   File "/nix/store/m8z2yhhk3zz2m54m5j5gis1knkx7hmzl-python3.8-lilgitd/bin/.lilgitd-wrapped", line 10, in <module>
#     import pygit2
#   File "/nix/store/sszh0x02c6kaazkvvnxax4iis2akfhm5-python3.8-pygit2-1.4.0/lib/python3.8/site-packages/pygit2/__init__.py", line 36, in <module>
#     from .config import Config
#   File "/nix/store/sszh0x02c6kaazkvvnxax4iis2akfhm5-python3.8-pygit2-1.4.0/lib/python3.8/site-packages/pygit2/config.py", line 26, in <module>
#     from cached_property import cached_property
#   File "/nix/store/5way8wx6hfd7p3c84lzr0rcycahqlkpk-python3.8-cached-property-1.5.1/lib/python3.8/site-packages/cached_property.py", line 12, in <module>
#     import asyncio
#   File "/nix/store/cf88yvm21kwal2bvgk8pgyjsbw3v0ixj-python3-3.8.6/lib/python3.8/asyncio/__init__.py", line 8, in <module>
#     from .base_events import *
#   File "/nix/store/cf88yvm21kwal2bvgk8pgyjsbw3v0ixj-python3-3.8.6/lib/python3.8/asyncio/base_events.py", line 45, in <module>
#     from . import staggered
#   File "/nix/store/cf88yvm21kwal2bvgk8pgyjsbw3v0ixj-python3-3.8.6/lib/python3.8/asyncio/staggered.py", line 6, in <module>
#     import typing
#   File "/nix/store/ky3z16f20y7gklmrz2r21f2f7bljwlwq-python2.7-typing-3.7.4.3/lib/python2.7/site-packages/typing.py", line 782, in <module>
#     AnyStr = TypeVar('AnyStr', bytes, unicode)
# NameError: name 'unicode' is not defined
```

When I poked around, I realized that resholve's python27 dependencies were in the PYTHONPATH. The current PR seems to fix this (not sure how canonically...) for `resholvePackage`, but I guess that ignores the real issue(s):

1. `resholve` itself [is built with buildPythonApplication](https://github.com/abathur/resholve/blob/master/resholve.nix#L30) and uses `propagatedBuildInputs` for its module dependencies (which, AFAIK, is correct). 
2. I thought the point of buildPythonApplication was to avoid leaking PYTHONPATH, so I'm a little confused. The docs say `Python applications can be installed in your profile, and will be wrapped to find their exact library dependencies, without impacting other applications or polluting your user environment.`
    - Am I holding it wrong?
    - Is there some subtle distinction between how they're treated when used as a buildInput vs added to a profile? 😬 
