### PR TITLE
Declare `wordswurst`’s `rev` and `hash` only once

### DIFF
--- a/make.nix
+++ b/make.nix
@@ -2,15 +2,7 @@
 
 with pkgs;
 let
-  # wordswurst = callPackage ../wordswurst { };
-  wordswurst = callPackage
-    (fetchFromGitHub {
-      owner = "abathur";
-      repo = "wordswurst";
-      rev = "66763c5f46cda53d6244383b1322d2699affe167";
-      hash = "sha256-d3ieqsYPNghCsid8WcW3z4wqQbtEFOu6kb8j8mxPuc4=";
-    })
-    { };
+  wordswurst = import ./wordswurst.nix { };
 in
 pkgs.mkShell {
   buildInputs = [ nix coreutils gnused groff util-linux wordswurst sassc ];

--- a/shell.nix
+++ b/shell.nix
@@ -9,15 +9,7 @@ let
   deps = callPackage ./deps.nix { };
   resholve = (callPackage ./default.nix { }).resholve;
   resolveTimeDeps = [ coreutils file findutils gettext ];
-  #wordswurst = callPackage ../wordswurst { };
-  wordswurst = callPackage
-    (fetchFromGitHub {
-      owner = "abathur";
-      repo = "wordswurst";
-      rev = "d3e687a29751d3a087c21ff751746feeb9164711";
-      hash = "sha256-dUrEzcf7EahrazWvLu4Yemh4ZTxxQRhcCbmLy6Y/LVk=";
-    })
-    { };
+  wordswurst = import ./wordswurst.nix { };
 in
 pkgs.mkShell {
   buildInputs = [ resholve bats nixpkgs-fmt cloc wordswurst sassc scss-lint ];

--- a/wordswurst.nix
+++ b/wordswurst.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+with pkgs;
+#callPackage ../wordswurst { }
+callPackage
+  (fetchFromGitHub {
+    owner = "abathur";
+    repo = "wordswurst";
+    rev = "66763c5f46cda53d6244383b1322d2699affe167";
+    hash = "sha256-d3ieqsYPNghCsid8WcW3z4wqQbtEFOu6kb8j8mxPuc4=";
+  })
+{ }


### PR DESCRIPTION
The `wordswurst` package gets used in both `make.nix` and `shell.nix`. Before
this change, both of those files would call `fetchFromGitHub` separately.
In order to change the `rev` used for `wordswurst`, you would have to change
both files.

e7d851c (bump wordswurst, 2023-09-01) was supposed to update `wordswurst`,
but unfortunately it only updated the version of `wordswurst` that’s used
by `make.nix`. This change makes it so that both `make.nix` and `shell.nix`
use the same version of `wordswurst` so that we don’t run into this
problem in the future.
