### PR TITLE
Add msmtp and msmtpq parsers

### DIFF
--- a/nixpkgs/test.nix
+++ b/nixpkgs/test.nix
@@ -62,7 +62,7 @@
 
 let
   default_packages = [ bash file findutils gettext ];
-  parsed_packages = [ coreutils sqlite unixtools.script gnused gawk findutils rlwrap gnutar bc ];
+  parsed_packages = [ coreutils sqlite unixtools.script gnused gawk findutils rlwrap gnutar bc msmtp ];
 in
 rec {
   module1 = resholve.mkDerivation {

--- a/resholve
+++ b/resholve
@@ -2446,6 +2446,139 @@ class ExternalCommandParsers(object):
 
         return (generic,)
 
+    @staticmethod
+    def _msmtp():
+        """
+        This was based on running "msmtp --help" with msmtp v1.8.24.
+        """
+        generic = CommandParser("msmtp")
+
+        # General options
+        generic.add_argument(
+            "--version",
+            "--help",
+            "-P", "--pretend",
+            "-v", "-d", "--debug",
+            action="store_true"
+        )
+
+        # Changing the mode of operation
+        generic.add_argument("--configure", nargs=1)
+        generic.add_argument("-S", "--serverinfo", action="store_true")
+        generic.add_argument("--rmqs", nargs=1)
+
+        # Configuration options
+        generic.add_argument("-C", "--file", nargs=1)
+        # For msmtp, "-a" is nargs=1.
+        # For msmtpq, "--q-mgmt -a" is nargs=0.
+        generic.add_argument("-a", nargs="?")
+        generic.add_argument(
+            "--account",
+            "--host",
+            "--port",
+            nargs=1
+        )
+        generic.add_argument(
+            "--source-ip",
+            "--proxy-host",
+            "--proxy-port",
+            "--socket",
+            "--timeout",
+            "--protocol",
+            "--domain",
+            "--auth",
+            "--user",
+            nargs="?"
+        )
+        generic.add_argument(
+            "--passwordeval",
+            dest="commands",
+            action="invocations",
+            nargs=1
+        )
+        generic.add_argument(
+            "--tls",
+            "--tls-starttls",
+            "--tls-trust-file",
+            "--tls-crl-file",
+            "--tls-fingerprint",
+            "--tls-certcheck",
+            "--tls-key-file",
+            "--tls-cert-file",
+            "--tls-priorities",
+            "--tls-host-override",
+            "--tls-min-dh-prime-bits",
+            nargs="?"
+        )
+
+        # Options specific to sendmail mode
+        generic.add_argument(
+            "--auto-from",
+            "-f", "--from=address",
+            "--maildomain",
+            "-N", "--dsn-notify",
+            "-R", "--dsn-return",
+            "-X", "--logfile",
+            "--logfile-time-format",
+            "--syslog",
+            nargs="?"
+        )
+        generic.add_argument(
+            "-t", "--read-recipients",
+            "--read-envelope-from",
+            action="store_true"
+        )
+        generic.add_argument(
+            "--aliases",
+            "--set-from-header",
+            "--set-date-header",
+            "--set-msgid-header",
+            "--remove-bcc-headers",
+            "--undisclosed-recipients",
+            nargs="?"
+        )
+        # Accepted but ignored:
+        generic.add_argument("-A", action="store_true")
+        generic.add_argument("-B", nargs=1)
+        generic.add_argument("-bm", action="store_true")
+        generic.add_argument("-F", nargs=1)
+        generic.add_argument("-G", action="store_true")
+        # For msmtp, "-h" is nargs=1.
+        # For msmtpq "--q-mgmt -h" is nargs=0.
+        generic.add_argument("-h", nargs="?")
+        generic.add_argument("-i", action="store_true")
+        generic.add_argument("-L", nargs=1)
+        generic.add_argument(
+            "-m",
+            "-n",
+            action="store_true"
+        )
+        generic.add_argument(
+            "-O",
+            # See <https://github.com/abathur/resholve/pull/103#issuecomment-1710979420>
+            action="count"
+        )
+        generic.add_argument("-o", nargs=1)
+
+        return (generic,)
+
+    @classmethod
+    def _msmtpq(cls):
+        """
+        This was based on running "msmtpq --q-mgmt -h" with msmtp v1.8.24.
+        """
+        generic = cls._msmtp()[0]
+
+        # -R, -d, -a and -h are already handled by the msmtp parser.
+        generic.add_argument(
+            "--q-mgmt",
+            "-r",
+            "-p",
+            action="store_true"
+        )
+
+        return (generic,)
+
 
 def generate_builtin_command_parser(cmdname):
     cmdname = "_" + cmdname

--- a/tests/parse_msmtp.sh
+++ b/tests/parse_msmtp.sh
@@ -1,0 +1,25 @@
+temp_dir="$(mktemp -d --suffix=resholve-tests-parse-msmtp)"
+trap 'rm -rf -- "$temp_dir"' EXIT
+config="$temp_dir/msmtprc"
+email="$temp_dir/test.eml"
+export MSMTPQ_LOG="$temp_dir/msmtpq_log"
+export MSMTPQ_Q="$temp_dir/msmtpq_q"
+# TODO: We can remove this next line once this Nixpkgs PR gets merged:
+# <https://github.com/NixOS/nixpkgs/pull/296720>
+export MSMTP_LOG="$MSMTPQ_LOG" MSMTP_QUEUE="$MSMTPQ_Q"
+
+echo '
+    account default
+    host example.com
+' > "$config"
+echo -ne 'To: foo@example.org\r\n' > "$email"
+echo -ne 'MIME-Version: 1.0\r\n' >> "$email"
+echo -ne '\r\n' >> "$email"
+
+< "$email" msmtp -PC "$config" --passwordeval=cat
+< "$email" msmtp -PC "$config" --passwordeval cat
+< "$email" msmtpq -PC "$config" --passwordeval=cat
+< "$email" msmtpq -PC "$config" --passwordeval cat
+# TODO: These commands are valid, but our parse doesn’t support them yet.
+#< "$email" msmtp -PC "$config" --passwordeval=
+#< "$email" msmtpq -PC "$config" --passwordeval=


### PR DESCRIPTION
Here are some things that I’m not sure about:

- I added more `add_argument()` calls than I needed to. I wanted to keep the code organized into the same categories that `msmtp --help` uses. I think that I could have combined a bunch of them like `_tar()` does. Would it be better if I did that? I was mainly trying to make sure that I didn’t accidentally skip over something.

- I used `nargs=1` for `--passwordeval`. msmtp’s manual makes it seem like I should have used `nargs="?"`, but that doesn’t seem to work.

- This breaks the parser, but I’m not sure why:

    ```bash
    msmtp -O foo=bar
    ```

    Log:

    ```none
    WARNING:__main__:CommandParser CommandParser(prog='msmtp (generic)', usage=None, description=None, version=None, formatter_class=<class 'argparse.HelpFormatter'>, conflict_handler='error', add_help=False) passing instead of 'argument -O/-o: expected 1 argument(s)'
      msmtp -O foo=bar
      ^~~~~
    '/hdd/home/jayman/VC/Git/Partially mine/resholve/bugs/msmtp-test.sh':3: 'msmtp' executes its arguments in some circumstances, and none of my command-specific rules for figuring out if this specific invocation does or not succeeded. Look above for warning messages with more context on what went wrong.
    ```

    Edit: This has been fixed.

Additionally, the `msmtpq` parser depends on abathur/binlore#12. That PR should be merged before this PR is merged.
