### PR TITLE
Add parser for `flatpak` and `flatpak update`

### DIFF
--- a/resholve
+++ b/resholve
@@ -2395,6 +2395,68 @@ class ExternalCommandParsers(object):
 
         return (generic,)
 
+    @staticmethod
+    def _flatpak():
+        """
+        Based on Flatpak v1.14.4.
+        """
+        generic = CommandParser("flatpak")
+
+        # flatpak --help
+        generic.add_argument(
+            "-h", "--help",
+            "--version",
+            "--default-arch",
+            "--supported-arches",
+            "--gl-drivers",
+            "--installations",
+            "--print-updated-env",
+            "--print-system-only",
+            "-v", "--verbose",
+            "--ostree-verbose",
+            action="store_true"
+        )
+        subparsers = generic.add_subparsers()
+        # flatpak update --help
+        update = subparsers.add_parser("update")
+        update.add_argument(
+            "-h", "--help",
+            "-u", "--user",
+            "--system",
+            action="store_true"
+        )
+        update.add_argument(
+            "--installation",
+            "--arch",
+            "--commit",
+            nargs=1
+        )
+        update.add_argument(
+            "--force-remove",
+            "--no-pull",
+            "--no-deploy",
+            "--no-related",
+            "--no-deps",
+            "--no-static-deltas",
+            "--runtime",
+            "--app",
+            "--appstream",
+            action="store_true"
+        )
+        update.add_argument("--subpath", nargs=1)
+        update.add_argument(
+            "-y", "--assumeyes",
+            "--noninteractive",
+        )
+        update.add_argument("--sideload-repo", nargs=1)
+        update.add_argument(
+            "-v", "--verbose",
+            "--ostree-verbose",
+            action="store_true"
+        )
+
+        return (generic,)
+
 
 def generate_builtin_command_parser(cmdname):
     cmdname = "_" + cmdname

--- a/resholve
+++ b/resholve
@@ -3837,6 +3837,9 @@ class RecordCommandlike(object):
         return True
 
     def handle_external_generic(self, parsed, invocation):
+        if not hasattr(parsed, "commands"):
+            return True
+
         # TODO: shimming shells in here may be a bigger crime than
         #       duplicating the logic in two functions would be?
         shell = invocation.firstword in INVOKABLE_SHELLS


### PR DESCRIPTION
This PR only implements a parser for `flatpak` and one of its subcommands. I think that #90 would have to be dealt with before a parser that supports all of `flatpak`’s subcommands and arguments could be implemented.

I’m submitting this as a draft because always crashes at the moment:

```none
Traceback (most recent call last):
  File "/nix/store/r910kd7i50jhfv48r4w2ak6g112vjmj9-resholve-0.9.0/bin/.resholve-wrapped", line 4807, in <module>
    sys.exit(punshow())
  File "/nix/store/r910kd7i50jhfv48r4w2ak6g112vjmj9-resholve-0.9.0/bin/.resholve-wrapped", line 947, in punshow
    resolve_cmdlikes()
  File "/nix/store/r910kd7i50jhfv48r4w2ak6g112vjmj9-resholve-0.9.0/bin/.resholve-wrapped", line 3175, in resolve_cmdlikes
    cmdlike.resolve()
  File "/nix/store/r910kd7i50jhfv48r4w2ak6g112vjmj9-resholve-0.9.0/bin/.resholve-wrapped", line 3147, in resolve
    self._resolve_invocations(solution)
  File "/nix/store/r910kd7i50jhfv48r4w2ak6g112vjmj9-resholve-0.9.0/bin/.resholve-wrapped", line 3106, in _resolve_invocations
    source.look_for_external_sub_execution(self.name, invocation)
  File "/nix/store/r910kd7i50jhfv48r4w2ak6g112vjmj9-resholve-0.9.0/bin/.resholve-wrapped", line 4076, in look_for_external_sub_execution
    if externals[subcmd]:
  File "/nix/store/r910kd7i50jhfv48r4w2ak6g112vjmj9-resholve-0.9.0/bin/.resholve-wrapped", line 1332, in __missing__
    return self.setdefault(key, self.factory(key))
  File "/nix/store/r910kd7i50jhfv48r4w2ak6g112vjmj9-resholve-0.9.0/bin/.resholve-wrapped", line 2472, in generate_external_command_parser
    return getattr(ExternalCommandParsers, cmdname)()
  File "/nix/store/r910kd7i50jhfv48r4w2ak6g112vjmj9-resholve-0.9.0/bin/.resholve-wrapped", line 2422, in _flatpak
    update = subparsers.add_parser("update")
  File "/nix/store/r3qy746fdmdx402xy6x1ymn0n8rx013a-python-2.7.18.6/lib/python2.7/argparse.py", line 1070, in add_parser
    parser = self._parser_class(**kwargs)
TypeError: __init__() got an unexpected keyword argument 'prog'
```

It looks like [`CommandParser`](https://github.com/abathur/resholve/blob/5e0956bd39a94159119647a13270841bb183f73e/resholve#L1379) doesn’t support all of the arguments that [`ArgumentParser`](https://docs.python.org/2/library/argparse.html#argumentparser-objects) does. Adding a subparser causes a new `CommandParser` to get created, and that causes the unexpected keyword argument error. I tried adding additional keyword arguments to `CommandParser.__init__()`, but then I ran into more errors, and I’m still not sure if that’s the right solution to this problem.
